### PR TITLE
Fixing the width of the github btns on at the home

### DIFF
--- a/index.soy
+++ b/index.soy
@@ -20,8 +20,8 @@
           A blazing-fast Single Page Application engine
         </p>
         <p class="gh-btns">
-          <iframe src="http://ghbtns.com/github-btn.html?user=eduardolundgren&amp;repo=senna&amp;type=watch&amp;count=true&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="120" height="30"></iframe>
-          <iframe src="http://ghbtns.com/github-btn.html?user=eduardolundgren&amp;repo=senna&amp;type=fork&amp;count=true&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="120" height="30"></iframe>
+          <iframe src="http://ghbtns.com/github-btn.html?user=eduardolundgren&amp;repo=senna&amp;type=watch&amp;count=true&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="150" height="30"></iframe>
+          <iframe src="http://ghbtns.com/github-btn.html?user=eduardolundgren&amp;repo=senna&amp;type=fork&amp;count=true&amp;size=large" allowtransparency="true" frameborder="0" scrolling="0" width="150" height="30"></iframe>
         </p>
       </div>
     </div>


### PR DESCRIPTION
This is to fix the github fork and star buttons at the home page, with the old widht they wasn't showing the numbers.

![captura de tela 2014-08-26 as 00 52 18](https://cloud.githubusercontent.com/assets/2625083/4039842/7f48ea34-2cd4-11e4-80fc-8a1ea0535a33.png)
